### PR TITLE
change grp in /opt/idsvr so it can run in openshift

### DIFF
--- a/5.1.0/ubuntu/Dockerfile
+++ b/5.1.0/ubuntu/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/* 
 
 RUN useradd --system idsvr
-USER idsvr:idsvr
 
 ENV IDSVR_HOME /opt/idsvr
 ENV JAVA_HOME $IDSVR_HOME/lib/java/jre
@@ -34,5 +33,9 @@ WORKDIR $IDSVR_HOME
 
 COPY --chown=idsvr idsvr-5.1.0/idsvr /opt/idsvr
 COPY --chown=idsvr first-run /opt/idsvr/etc/first-run
+
+RUN chgrp -R 0 /opt/idsvr && \
+    chmod -R g+rwX /opt/idsvr
+USER idsvr:idsvr
 
 CMD ["idsvr"]

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -25,7 +25,6 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/* 
 
 RUN useradd --system idsvr
-USER idsvr:idsvr
 
 ENV IDSVR_HOME /opt/idsvr
 ENV JAVA_HOME $IDSVR_HOME/lib/java/jre
@@ -34,5 +33,9 @@ WORKDIR $IDSVR_HOME
 
 COPY --chown=idsvr idsvr-{{VERSION}}/idsvr /opt/idsvr
 COPY --chown=idsvr first-run /opt/idsvr/etc/first-run
+
+RUN chgrp -R 0 /opt/idsvr && \
+    chmod -R g+rwX /opt/idsvr
+USER idsvr:idsvr
 
 CMD ["idsvr"]


### PR DESCRIPTION
This is a fix in the ubuntu image according to Openshift's guidelines https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines, so that it can continue to assign a random user id in the containers that it starts. This does not apply in kubernetes but shouldn't have any effect. 

We can potentially add it on the other images as well