### PR TITLE
Feat/master/is 6433

### DIFF
--- a/build-arm-images.sh
+++ b/build-arm-images.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_CONTEXT=${VERSION}
+
+build_image() {
+  IMAGE=$1
+  DOCKERFILE=$2
+  if [[ -f "${DOCKERFILE}" ]] ; then
+
+    # Find the base image used in the dockerfile
+    BASE_IMAGE=$(cat "${DOCKERFILE}" | grep FROM | tail -1 | sed -e 's/FROM[[:space:]]//g')
+    echo "BASE_IMAGE: ${BASE_IMAGE}"
+
+    # Get the last layer id of the base image
+    BASE_IMAGE_LAST_LAYER_ID=$(docker inspect "${BASE_IMAGE}" | jq ".[0].RootFS.Layers[-1]")
+    echo "BASE_IMAGE_LAST_LAYER_ID: ${BASE_IMAGE_LAST_LAYER_ID}"
+
+    # Download the current published image and inspect it
+    docker pull "${IMAGE}" || true
+    IMAGE_INSPECT=$(docker inspect "${IMAGE}" || true)
+
+    # Check if the last layer of the base image exists in the published one
+    if [[ $IMAGE_INSPECT != *$BASE_IMAGE_LAST_LAYER_ID* ]]  || [[ $FORCE_UPDATE_VERSION == *$VERSION* ]]; then
+      ARTIFACT=linux-arm ./download-release.sh
+
+      # Build the image again
+      docker build --no-cache -t "${IMAGE}" -f "${DOCKERFILE}" "${DOCKER_CONTEXT}"
+
+      #Run sanity tests if RUN_SANITY_CHECK is set
+      MAJOR_VERSION=(${VERSION//./ }[0])
+      if [[ -n "${RUN_SANITY_CHECK}" ]] && [[ ${MAJOR_VERSION} -ge 5 ]] ; then
+        echo "Running Sanity tests on image: ${IMAGE}"
+        ./../tests/sanity-tests.sh 1 curity-idsvr admin Password1 ${IMAGE};
+      fi
+
+      #Run bats test if RUN_BATS_TEST is set
+      if [[ -n "${RUN_BATS_TEST}" ]] ; then
+        echo "Running Bats tests on image: ${IMAGE}"
+        export BATS_CURITY_IMAGE=${IMAGE}
+        tests/bats/bin/bats tests
+      fi
+
+      if [[ -n "${PUSH_IMAGES}" ]] ; then
+        echo "Pushing image: ${IMAGE}"
+        docker push "${IMAGE}";
+      fi
+
+    else
+      echo "Skip pushing ${IMAGE} because it is unchanged"
+    fi
+  fi
+}
+
+build_image "curity.azurecr.io/curity/idsvr:${VERSION}-arm" "${VERSION}/ubuntu/Dockerfile"

--- a/build-images.sh
+++ b/build-images.sh
@@ -23,7 +23,7 @@ build_image() {
 
     # Check if the last layer of the base image exists in the published one
     if [[ $IMAGE_INSPECT != *$BASE_IMAGE_LAST_LAYER_ID* ]]  || [[ $FORCE_UPDATE_VERSION == *$VERSION* ]]; then
-     ./download-release.sh
+      ARTIFACT=linux ./download-release.sh
 
       # Build the image again
       docker build --no-cache -t "${IMAGE}" -f "${DOCKERFILE}" "${DOCKER_CONTEXT}"
@@ -153,8 +153,12 @@ if [[ "$VERSION" == *.0 ]]; then
   EXTRA_TAGS_BUSTER="curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-buster"
   EXTRA_TAGS_BUSTER_SLIM="curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-buster-slim curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-slim"
 fi
+if [[ "$VERSION" < "7.0.0" ]]; then
+  build_image "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18.04" "${VERSION}/ubuntu/Dockerfile" "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu" "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18" "curity.azurecr.io/curity/idsvr:${VERSION}" $EXTRA_TAGS_UBUNTU
+else
+  build_image "curity.azurecr.io/curity/idsvr:${VERSION}-x86" "${VERSION}/ubuntu/Dockerfile"
+fi
 
-build_image "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18.04" "${VERSION}/ubuntu/Dockerfile" "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu" "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18" "curity.azurecr.io/curity/idsvr:${VERSION}" $EXTRA_TAGS_UBUNTU
 build_image "curity.azurecr.io/curity/idsvr:${VERSION}-${CENTOS_VERSION}" "${VERSION}/centos/Dockerfile" "curity.azurecr.io/curity/idsvr:${VERSION}-centos" $EXTRA_TAGS_CENTOS
 build_image "curity.azurecr.io/curity/idsvr:${VERSION}-buster" "${VERSION}/buster/Dockerfile" $EXTRA_TAGS_BUSTER
 build_image "curity.azurecr.io/curity/idsvr:${VERSION}-buster-slim" "${VERSION}/buster-slim/Dockerfile" "curity.azurecr.io/curity/idsvr:${VERSION}-slim" $EXTRA_TAGS_BUSTER_SLIM

--- a/create-ubuntu-multiplatform-image.sh
+++ b/create-ubuntu-multiplatform-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+ARM_IMAGE="curity.azurecr.io/curity/idsvr:${VERSION}-arm"
+X86_IMAGE="curity.azurecr.io/curity/idsvr:${VERSION}-x86"
+
+docker pull "$ARM_IMAGE"
+docker pull "$X86_IMAGE"
+
+
+if [[ "$VERSION" == *.0 ]]; then
+  BRANCH_VERSION=${VERSION%??}
+  EXTRA_TAGS_UBUNTU="curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-ubuntu
+  curity.azurecr.io/curity/idsvr:${BRANCH_VERSION} curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-ubuntu18
+  curity.azurecr.io/curity/idsvr:${BRANCH_VERSION}-ubuntu18.04"
+fi
+
+# shellcheck disable=SC2206
+TAG_ARRAY=("curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18.04" "curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu"
+"curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18" "curity.azurecr.io/curity/idsvr:${VERSION}" $EXTRA_TAGS_UBUNTU)
+
+
+for m in "${TAG_ARRAY[@]}"; do
+  docker manifest create "$m" ARM_IMAGE X86_IMAGE
+  docker manifest push "$m"
+done

--- a/create-ubuntu-multiplatform-image.sh
+++ b/create-ubuntu-multiplatform-image.sh
@@ -22,6 +22,6 @@ TAG_ARRAY=("curity.azurecr.io/curity/idsvr:${VERSION}-ubuntu18.04" "curity.azure
 
 
 for m in "${TAG_ARRAY[@]}"; do
-  docker manifest create "$m" ARM_IMAGE X86_IMAGE
+  docker manifest create "$m" "$ARM_IMAGE" "$X86_IMAGE"
   docker manifest push "$m"
 done

--- a/download-release.sh
+++ b/download-release.sh
@@ -18,13 +18,13 @@ if [[ "${ACCESS_TOKEN}" == "null" ]]; then
 fi
 
 # Download the release from the release API
-RELEASE_FILENAME="idsvr-${VERSION}-linux.tar.gz"
+RELEASE_FILENAME="idsvr-${VERSION}-${ARTIFACT}.tar.gz"
 if [ ! -f $RELEASE_FILENAME ]; then
-  curl -f -s -S -H "Authorization: Bearer ${ACCESS_TOKEN}" "${RELEASE_API}/${VERSION}/linux-release" > "${RELEASE_FILENAME}"
+  curl -f -s -S -H "Authorization: Bearer ${ACCESS_TOKEN}" "${RELEASE_API}/${VERSION}/${ARTIFACT}-release" > "${RELEASE_FILENAME}"
 fi
 
 # Verify hash of downloaded file
-RELEASE_HASH=$(curl -f -s -S -H "Authorization: Bearer ${ACCESS_TOKEN}" "${RELEASE_API}/${VERSION}" | jq -r '."linux-sha256-checksum"')
+RELEASE_HASH=$(curl -f -s -S -H "Authorization: Bearer ${ACCESS_TOKEN}" "${RELEASE_API}/${VERSION}" | jq -r ".\"${ARTIFACT}-sha256-checksum\"")
 echo "${RELEASE_HASH}" "${RELEASE_FILENAME}" | sha256sum -c
 
 tar -xf "${RELEASE_FILENAME}" -C "${VERSION}"

--- a/update-arm-images.sh
+++ b/update-arm-images.sh
@@ -2,12 +2,8 @@
 
 set -e
 
-DATE=$(/bin/date +%Y%m%d)
-
 [[ -z "${CLIENT_ID}" ]] && echo "CLIENT_ID not set" >&2 && exit 1;
 [[ -z "${CLIENT_SECRET}" ]] && echo "CLIENT_SECRET not set" >&2 && exit 1;
-
-LATEST_RELEASE=$(find -- * -maxdepth 0 -type d | sort -rh | head -n 1)
 
 # Pull base images once to avoid pull limit in dockerhub
 docker pull ubuntu:18.04

--- a/update-arm-images.sh
+++ b/update-arm-images.sh
@@ -16,3 +16,7 @@ if ! [[ "$VERSION" < "7.0.0" ]]; then
   ./create-ubuntu-multiplatform-image.sh
 fi
 done < <(find -- * -name "[0-9].[0-9].[0-9]" -type d | sort -r)
+
+# Delete stopped containers and images
+docker ps -a | awk '{ print $1,$2 }' | grep "curity.azurecr.io/curity/idsvr" | awk '{print $1 }' | xargs -I {} docker rm {}
+docker images | awk '{ print $1,$3 }' | grep "curity.azurecr.io/curity/idsvr" | awk '{print $2 }' | xargs -I {} docker rmi {} --force

--- a/update-arm-images.sh
+++ b/update-arm-images.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+DATE=$(/bin/date +%Y%m%d)
+
+[[ -z "${CLIENT_ID}" ]] && echo "CLIENT_ID not set" >&2 && exit 1;
+[[ -z "${CLIENT_SECRET}" ]] && echo "CLIENT_SECRET not set" >&2 && exit 1;
+
+LATEST_RELEASE=$(find -- * -maxdepth 0 -type d | sort -rh | head -n 1)
+
+# Pull base images once to avoid pull limit in dockerhub
+docker pull ubuntu:18.04
+
+while IFS= read -r VERSION
+do
+if ! [[ "$VERSION" < "7.0.0" ]]; then
+  export VERSION=${VERSION}
+  ./build-arm-images.sh
+  ./create-ubuntu-multiplatform-image.sh
+fi
+done < <(find -- * -name "[0-9].[0-9].[0-9]" -type d | sort -r)

--- a/update-images.sh
+++ b/update-images.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-DATE=$(/bin/date +%Y%m%d)
-
 [[ -z "${CLIENT_ID}" ]] && echo "CLIENT_ID not set" >&2 && exit 1;
 [[ -z "${CLIENT_SECRET}" ]] && echo "CLIENT_SECRET not set" >&2 && exit 1;
 

--- a/update-images.sh
+++ b/update-images.sh
@@ -25,23 +25,6 @@ do
 
 done < <(find -- * -name "[0-9].[0-9].[0-9]" -type d | sort -r)
 
-## Push the latest tag if updated
-
-# Download the current published latest
-docker pull curity.azurecr.io/curity/idsvr:latest || true
-
-
-CURRENT_LATEST_LAST_LAYER_ID=$(docker inspect curity.azurecr.io/curity/idsvr:latest | jq ".[0].RootFS.Layers[-1]")
-LATEST_IMAGE_INSPECT=$(docker inspect "curity.azurecr.io/curity/idsvr:${LATEST_RELEASE}-ubuntu18.04")
-
-if [[ $LATEST_IMAGE_INSPECT != *$CURRENT_LATEST_LAST_LAYER_ID* ]]; then
-  if [[ -n "${PUSH_IMAGES}" ]] ; then
-    echo "Pushing image: curity.azurecr.io/curity/idsvr:latest"
-    docker tag "curity.azurecr.io/curity/idsvr:${LATEST_RELEASE}-ubuntu18.04" curity.azurecr.io/curity/idsvr:latest && docker push curity.azurecr.io/curity/idsvr:latest;
-  fi
-fi
-
 # Delete stopped containers and images
 docker ps -a | awk '{ print $1,$2 }' | grep "curity.azurecr.io/curity/idsvr" | awk '{print $1 }' | xargs -I {} docker rm {}
-docker rmi curity.azurecr.io/curity/idsvr:latest
 docker images | awk '{ print $1,$3 }' | grep "curity.azurecr.io/curity/idsvr" | awk '{print $2 }' | xargs -I {} docker rmi {} --force

--- a/update-latest.sh
+++ b/update-latest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+LATEST_RELEASE=$(find -- * -maxdepth 0 -type d | sort -rh | head -n 1)
+
+ARM_IMAGE="curity.azurecr.io/curity/idsvr:${LATEST_RELEASE}-arm"
+X86_IMAGE="curity.azurecr.io/curity/idsvr:${LATEST_RELEASE}-x86"
+LATEST_TAG="curity.azurecr.io/curity/idsvr:latest"
+
+docker pull "$ARM_IMAGE"
+docker pull "$X86_IMAGE"
+
+CURRENT_LATEST_MULTIPLATFORM_MANIFEST=$(docker manifest inspect "${LATEST_TAG}")
+LATEST_ARM_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${ARM_IMAGE}" | sed "s/.*sha256://g")
+LATEST_X86_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${X86_IMAGE}" | sed "s/.*sha256://g")
+
+
+if [[ $CURRENT_LATEST_MULTIPLATFORM_MANIFEST != *$LATEST_ARM_IMAGE_DIGEST*  || $CURRENT_LATEST_MULTIPLATFORM_MANIFEST != *$LATEST_X86_IMAGE_DIGEST* ]]; then
+  if [[ -n "${PUSH_IMAGES}" ]] ; then
+    echo "Pushing image: $LATEST_TAG"
+    docker manifest rm "$LATEST_TAG" || true
+    docker manifest create "$LATEST_TAG" "$ARM_IMAGE" "$X86_IMAGE"
+    docker manifest push "$LATEST_TAG"
+  fi
+fi
+
+docker rmi "$ARM_IMAGE" "$X86_IMAGE" "$LATEST_TAG" || true


### PR DESCRIPTION
The changes below are intended to:

For versions after 7.0.0
1. The `update-images.sh` only pushes a tag with the name `curity.azurecr.io/curity/idsvr:${VERSION}-x86` for the ubuntu image
2. The `update-arm-images.sh` should run in an arm machine, which should build only the `curity.azurecr.io/curity/idsvr:${VERSION}-arm` image and push the multiplatform images with all the tags we used previously 
3. Updating the latest tag was moved out to a different script to run independently 


Also 5.x.x versions were removed because they will no longer be supported after 7.0.0 is out